### PR TITLE
Include old and new filenames where a file has been renamed

### DIFF
--- a/github.rb
+++ b/github.rb
@@ -23,10 +23,13 @@ class GithubClient
   end
 
   def files_in_pr
-    client.pull_request_files(repo, pr_number)
-      .map(&:filename)
-      .sort
-      .uniq
+    client.pull_request_files(repo, pr_number).flat_map do |f|
+      if f.status == "renamed" && f.respond_to?(:previous_filename) && f.previous_filename
+        [f.filename, f.previous_filename]
+      else
+        [f.filename]
+      end
+    end.sort.uniq
   end
 
   def commit_changes(message)


### PR DESCRIPTION
If the PR includes renamed files, check that they aren't being named across namespaces. This is particularly important for namespace renames where the deletion process will not work properly if users rename the namespace folder rather than deleting it and creating a new one.